### PR TITLE
Undefined names: import os, pandas, uuid

### DIFF
--- a/third_party/baselines/bench/monitor.py
+++ b/third_party/baselines/bench/monitor.py
@@ -1,13 +1,17 @@
 # coding=utf-8
 __all__ = ['Monitor', 'get_monitor_files', 'load_results']
 
+import csv
+import json
+import os
+import os.path as osp
+import time
+import uuid
+from glob import glob
+
 import gym
 from gym.core import Wrapper
-import time
-from glob import glob
-import csv
-import os.path as osp
-import json
+import pandas
 import numpy as np
 
 class Monitor(Wrapper):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/google-research/episodic-curiosity on Python 3.9.0rc2+

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./third_party/baselines/bench/monitor.py:143:55: F821 undefined name 'uuid'
    mon_file = "/tmp/baselines-test-%s.monitor.csv" % uuid.uuid4()
                                                      ^
./third_party/baselines/bench/monitor.py:159:20: F821 undefined name 'pandas'
    last_logline = pandas.read_csv(f, index_col=None)
                   ^
./third_party/baselines/bench/monitor.py:162:5: F821 undefined name 'os'
    os.remove(mon_file)
    ^
3     F821 undefined name 'uuid'
3
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.